### PR TITLE
Example site: fix error

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,20 @@ To get started with Pehtheme Hugo, follow these steps:
 
 ## Configuration
 
-You can configure the following settings in your Hugo project:
+You can configure the following settings for your Hugo project
+ by adding or modifying these lines in your config file `hugo.toml`:
 
-- `paginate` = '6' (Set the desired number of home posts per page)
-- `summaryLength` = '20' (Approximately 160 characters for 20 words)
-- `googleAnalytics` = '' (Your GA-4 analytics code)
-- `disqusShortname` = '' (Your Disqus shortname)
+summaryLength = 20 # (approximately 160 characters for 20 words)
+
+[services]
+  [services.googleAnalytics]
+    id = 'G-MEASUREMENT_ID' # (Your GA-4 analytics code)
+
+  [services.disqus]
+    shortname = 'shortname' # (Your Disqus shortname)
+
+[pagination]
+  pagerSize = 10 # (Set the desired number of home posts per page)
 
 ## Custom Theme
 

--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,0 +1,3 @@
+.hugo_build.lock
+public/
+resources/

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -3,7 +3,6 @@ languageCode = 'en-us'
 title = 'Pehtheme'
 theme = 'pehtheme-hugo'
 
-paginate = '6' # <- Set the desired number of posts per page 
 summaryLength = '20' # <- 20 words are approximately 160 characters
 googleAnalytics = 'G-MEASUREMENT_ID' # <- Your GA-4
 disqusShortname = 'your-disqus-shortname' # <- Get form here : https://disqus.com
@@ -18,6 +17,9 @@ disqusShortname = 'your-disqus-shortname' # <- Get form here : https://disqus.co
 	bio = 'Debitis assumenda esse dignissimos aperiam delectus maxime tenetur repudiandae dolore'
 	avatar = '/images/nasa-astronaut-unsplash.jpg'
 	twitter = 'https://twitter.com/insertapps'
+
+[pagination]
+	pagerSize = 6 # <- Set the desired number of posts per page 
 
 [menu] # Menu management
 	[[menu.main]]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,9 +17,9 @@
       
       <div id="writer" class="flex items-center space-x-4">
 
-        {{- $name := .Site.Author.name -}}
+        {{- $name := .Site.Params.Author.name -}}
 
-        {{- with $avatar := resources.Get .Site.Author.avatar }}
+        {{- with $avatar := resources.Get .Site.Params.Author.avatar }}
 
         <img class="w-12 h-12 bg-black rounded-full" src="{{ $avatar.Permalink }}" alt="{{ $name }} avatar" width="{{ $avatar.Width }}" height="{{ $avatar.Height }}">
 
@@ -27,7 +27,7 @@
         
         <ul class="flex items-center space-x-4 flex-nowrap whitespace-nowrap overflow-x-auto">
           
-          <li class="font-semibold my-2">{{ .Site.Author.name }}</li>
+          <li class="font-semibold my-2">{{ .Site.Params.Author.name }}</li>
           
           <li class="before:content-['•'] before:mr-2 before:opacity-50 my-2">
             {{- $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" -}}
@@ -95,11 +95,11 @@
 
       <div id="author-box" class="my-8 md:my-14 border p-8 bg-zinc-100 rounded-2xl">
 
-        <img class="w-20 h-20 rounded-full" src="{{ .Site.Author.avatar }}" alt="{{ .Site.Author.name }}">
+        <img class="w-20 h-20 rounded-full" src="{{ .Site.Params.Author.avatar }}" alt="{{ .Site.Params.Author.name }}">
 
-        <h2 class="text-xl font-bold my-4">Writter by : {{ .Site.Author.name }}</h2>
+        <h2 class="text-xl font-bold my-4">Written by : {{ .Site.Params.Author.name }}</h2>
 
-        <p class="mb-4">{{ .Site.Author.bio }}</p>
+        <p class="mb-4">{{ .Site.Params.Author.bio }}</p>
 
         <ul class="flex flex-wrap space-x-4">
           <li>


### PR DESCRIPTION
When running the example site with latest hugo version 0.139.3, an error is thrown.

```
ERROR deprecated: .Site.Author was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.140.0.
Implement taxonomy 'author' or use .Site.Params.Author instead.
```

This PR fixes this issue.

This error closes #7.